### PR TITLE
Add fakeroot as installation requirement

### DIFF
--- a/source/intro/install.rst
+++ b/source/intro/install.rst
@@ -17,7 +17,7 @@ Installing dependencies
 
 .. code-block:: shell
 
-    sudo apt install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev
+    sudo apt install -y python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot
 
     # Install appimagetool AppImage
     sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool


### PR DESCRIPTION
When running the test fakeroot was missing. Installing it moved helped going one step further. I'm not on Ubuntu, but it might be that the package with the same name is required?