### PR TITLE
Update troubleshooting.rst

### DIFF
--- a/source/advanced/troubleshooting.rst
+++ b/source/advanced/troubleshooting.rst
@@ -17,6 +17,34 @@ the system. You can inspect then too look for missing packages or undesired exte
 **NOTE**: This file is only generated for AppImages built using ``appimage-builder`` >= v0.5.3.
 
 
+appimage-builder
+==================
+``appimage-builder`` may be used with two different log levels in its arguments. 
+The default ``--log`` level is ``INFO``,
+and the more informative ``--log`` level is ``DEBUG``.
+Users may specify log arguements in the ``appimage-builder``
+command using the ``--log LOGLEVEL`` argument where 
+"LOGLEVEL" is either "INFO" or "DEBUG".
+e.g. ``appimage-builder --log DEBUG --generate``
+
+.. code-block:: text
+
+    usage: appimage-builder [-h] [--recipe RECIPE] [--log LOGLEVEL < INFO | DEBUG> ] 
+                        [--skip-script] [--skip-build] [--skip-tests]
+                        [--skip-appimage] [--generate]
+
+    AppImage crafting tool
+    optional arguments:
+     -h, --help       show this help message and exit
+     --recipe RECIPE  recipe file path (default: $PWD/AppImageBuilder.yml)
+     --log LOGLEVEL   logging level (default: INFO, debug: DEBUG, e.g. appimage-builder --log DEBUG --generate)
+     --skip-script    Skip script execution
+     --skip-build     Skip AppDir building
+     --skip-tests     Skip AppDir testing
+     --skip-appimage  Skip AppImage generation
+     --generate       Try to generate recipe from an AppDir
+
+
 appimage-inspector
 ==================
 


### PR DESCRIPTION
Seems to me like those who wrote this think too much like programmers and too little like writers. A good thing I would say, but not in this case.
There is ZERO documentation of log level options in the --log argument when using the ``appimage-builder  --generate`` command. Then only reference to there being an option other than the default ``INFO`` option, is appimage-inspector troubleshooting documentation. This does not, however, help a user that is attempting to debug ``appimage-builder --generate``. After 3 days of trying to debug this, it took me a cold hard guess to pass ``DEBUG`` as a ``--log`` option. Why is this not documented? This option is needed when working with the strace tool or gdb tool as it lets us know at what point appimage-builder is coming to an unexpected halt. 
It took me days to figure this out. Please consider adding documentation in regards to the log options that can be passed. If there is a specific reason why this documentation is excluded, please state that reason, so end users know wtf is going on.