### PR TITLE
Fix missing code blocks on ReadTheDocs

### DIFF
--- a/source/intro/tutorial.rst
+++ b/source/intro/tutorial.rst
@@ -111,6 +111,7 @@ graphical interface set ``use_host_x`` to ``True``. This will share the host X11
 The generated recipe already comes with a set of tests configured, to run then use:
 
 .. code-block:: text
+
    appimage-builder --skip-build --skip-appimage
 
 **NOTE**: If the docker images are not in your system it may take a while to download.
@@ -133,6 +134,7 @@ You have made and tested and ``AppDir`` containing your application binaries and
 is to generate the AppImage as follows:
 
 .. code-block:: text
+
    appimage-builder --skip-build --skip-test
 
 


### PR DESCRIPTION
Those code blocks are not shown on https://appimage-builder.readthedocs.io/en/latest/intro/tutorial.html.

<img width="633" alt="image" src="https://user-images.githubusercontent.com/1798101/101153679-09245d00-3625-11eb-9c99-2097a977eeba.png">
