### PR TITLE
Correct typo

### DIFF
--- a/source/intro/tutorial.rst
+++ b/source/intro/tutorial.rst
@@ -35,7 +35,7 @@ Recipe Generation
 =================
 
 Once the application binaries are deployed to an ``AppDir`` we proceed to run ``appimage-builder --generate``. This
-will proceed to read the application executable from the desktop entry and launch it. The application will shows up
+will proceed to read the application executable from the desktop entry and launch it. The application will show up and
 you can proceed to close it. In complex applications where external plugins are used it's recommended to test all
 the features before closing, this will make sure that all runtime dependencies are identified.
 


### PR DESCRIPTION
To fix the other remaining ~ 40 typos on this page, you can install Grammarly, a browser plugin, that does detect grammar issues and typos and corrects them for you.