### PR TITLE
Update tutorial.rst

### DIFF
--- a/source/intro/tutorial.rst
+++ b/source/intro/tutorial.rst
@@ -58,7 +58,7 @@ the issue before continuing. Notice that applications must be relocatable in ord
 .. code-block:: shell
 
     # execute the application
-    AppDir/usr/bin/appimage-demo-qt5
+    AppDir/usr/bin/qt-appimage-template
 
 
 =====================


### PR DESCRIPTION
Replaced AppDir/usr/bin/appimage-demo-qt5 with AppDir/usr/bin/qt-appimage-template - So that the app can be found and started.