### PR TITLE
Add missing command to flutter example recipe to avoid error

### DIFF
--- a/source/examples/flutter.rst
+++ b/source/examples/flutter.rst
@@ -131,6 +131,7 @@ you don't want to use the `--generate` method.
      - rm -rf AppDir || true
      - cp -r build/linux/x64/release/bundle AppDir
      - mkdir -p AppDir/usr/share/icons/hicolor/64x64/apps/
+     - mv AppDir/lib/ AppDir/usr/
      - cp flutter-mark-square-64.png AppDir/usr/share/icons/hicolor/64x64/apps/
     AppDir:
       path: ./AppDir


### PR DESCRIPTION
When running the flutter example recipe , one ends up with the following error:

```
Traceback (most recent call last):
  File "/tmp/appimage-virtualenv/bin/appimage-builder", line 8, in <module>
    sys.exit(__main__())
  File "/tmp/appimage-virtualenv/lib/python3.10/site-packages/appimagebuilder/__main__.py", line 50, in __main__
    invoker.execute(commands)
  File "/tmp/appimage-virtualenv/lib/python3.10/site-packages/appimagebuilder/invoker.py", line 29, in execute
    command()
  File "/tmp/appimage-virtualenv/lib/python3.10/site-packages/appimagebuilder/commands/pacman_deploy.py", line 50, in __call__
    deployed_packages = pacman_deploy.deploy(
  File "/tmp/appimage-virtualenv/lib/python3.10/site-packages/appimagebuilder/modules/deploy/pacman/deploy.py", line 89, in deploy
    os.symlink("usr/lib", appdir_root / "lib")
FileExistsError: [Errno 17] File exists: 'usr/lib' -> '/tmp/AppDir/lib'
```

The fix is to move the AppDir/lib/ directory to AppDir/usr/