### PR TITLE
Drop path entry from AppDir section

### DIFF
--- a/source/advanced/full_bundle.rst
+++ b/source/advanced/full_bundle.rst
@@ -35,8 +35,6 @@ show how to create an full AppImage bundle for kcalc.
     version: 1
 
     AppDir:
-      path: ./AppDir
-
       app_info:
         id: org.kde.kcalc
         name: kcalc

--- a/source/examples/bash.rst
+++ b/source/examples/bash.rst
@@ -9,8 +9,6 @@ This recipe will generate a aarch64 (arm64) AppImage for bash. It's cross-built 
     version: 1
 
     AppDir:
-      path: ./AppDir
-
       app_info:
         id: org.gnu.bash
         name: bash

--- a/source/examples/flutter.rst
+++ b/source/examples/flutter.rst
@@ -134,7 +134,6 @@ you don't want to use the `--generate` method.
      - mv AppDir/lib/ AppDir/usr/
      - cp flutter-mark-square-64.png AppDir/usr/share/icons/hicolor/64x64/apps/
     AppDir:
-      path: ./AppDir
       app_info:
         id: org.appimagecrafters.hello-flutter
         name: Hello Flutter

--- a/source/examples/gambas3.rst
+++ b/source/examples/gambas3.rst
@@ -95,7 +95,6 @@ end a file name `AppImageBuilder.yml` will be created in the current working dir
     # appimage-builder recipe see https://appimage-builder.readthedocs.io for details
     version: 1
     AppDir:
-      path: ./AppDir
       app_info:
         id: org.appimagecrafters.gambas3-demo
         name: Gambas3 Demo

--- a/source/examples/gimp_path_mapping.rst
+++ b/source/examples/gimp_path_mapping.rst
@@ -45,8 +45,6 @@ Recipe
     version: 1
 
     AppDir:
-      path: ./AppDir
-
       app_info:
         id: gimp
         name: GNU Image Manipulation Program

--- a/source/examples/gnome.rst
+++ b/source/examples/gnome.rst
@@ -11,8 +11,6 @@ Gnome application (gnome-calculator)
     version: 1
 
     AppDir:
-      path: ./AppDir
-
       app_info:
         id: org.gnome.Calculator
         name: gnome-calculator

--- a/source/examples/kde.rst
+++ b/source/examples/kde.rst
@@ -7,8 +7,6 @@ Qt/Kde application (kcalc)
     version: 1
 
     AppDir:
-      path: ./AppDir
-
       app_info:
         id: org.kde.kcalc
         name: kcalc

--- a/source/examples/multimedia.rst
+++ b/source/examples/multimedia.rst
@@ -12,8 +12,6 @@ Multimedia application (VLC)
       - rm -r ./AppDir || true
 
     AppDir:
-      path: ./AppDir
-
       app_info:
         id: vlc
         name: VLC media player

--- a/source/examples/pyqt.rst
+++ b/source/examples/pyqt.rst
@@ -44,8 +44,6 @@ Recipe
 
 
     AppDir:
-      path: ./AppDir
-
       app_info:
         id: org.appimage-crafters.python-appimage-example
         name: python appimage hello world


### PR DESCRIPTION
This PR updates the documentation ro resemble a change from 2022/04 where `path` is dropped, commit [42a07aa](https://github.com/AppImageCrafters/appimage-builder/commit/42a07aab05980c087cee58187fc86204bacc98e4).